### PR TITLE
Add Bzz

### DIFF
--- a/repositories.yaml
+++ b/repositories.yaml
@@ -548,6 +548,8 @@ categories:
           - url: https://github.com/appledragon/everythingByMdfind
           - url: https://github.com/Serpentiel/betterglobekey
           - url: https://github.com/runjuu/InputSourcePro
+          - url: https://github.com/zlopixatel/bzz
+            description: Automatic keyboard layout switcher (RU↔EN), open-source replacement for Punto Switcher
           - url: https://github.com/balena-io/etcher
   - name: Terminal
     subcategories:


### PR DESCRIPTION
Adds [Bzz](https://github.com/zlopixatel/bzz) — open-source automatic keyboard layout switcher for macOS, in **System Tools → System Utilities** near InputSourcePro (similar input-handling utility).

- MIT, Go, no telemetry
- Active CGEventTap, fuzzy matching, Cmd+Z undo with per-app learning
- Replaces the abandoned Punto Switcher; one-time payment instead of Caramba's subscription