### PR TITLE
Add Dusty

### DIFF
--- a/repositories.yaml
+++ b/repositories.yaml
@@ -530,6 +530,8 @@ categories:
             description: Auto-quit unused apps for focus
           - url: https://github.com/alienator88/Pearcleaner
             description: Free and fair-code mac app cleaner
+          - url: https://github.com/yagcioglutoprak/dusty
+            description: Free, open-source macOS menu bar cleaner.
           - url: https://github.com/exelban/stats
           - url: https://github.com/gao-sun/eul
             description: macOS status monitoring app in SwiftUI


### PR DESCRIPTION
Adds Dusty under **System Tools → System Utilities**, alongside comparable macOS cleaners. Dusty is an actively maintained, MIT-licensed macOS menu bar cleaner.

- [x] Checked `repositories.yaml` to ensure that the repository is not already listed.
- [x] Checked the pull requests to ensure that another person has not already submitted the same repository.
- [x] Read the contributing guidelines.
- [x] Modified only `repositories.yaml`.
- [x] Repository being added is actively maintained (latest push: June 3, 2026).
- [x] Repository being added has an open source license (MIT).

Validation: `ruby -e 'require "yaml"; YAML.load_file("repositories.yaml")'` and `git diff --check` both pass.