### PR TITLE
Add usage to System Tools > Menu Bar

### DIFF
--- a/repositories.yaml
+++ b/repositories.yaml
@@ -503,6 +503,8 @@ categories:
             description: Show battery of all devices in Dock
           - url: https://github.com/pakerwreah/Calendr
           - url: https://github.com/kmikiy/SpotMenu
+          - url: https://github.com/aqua5230/usage
+            description: Claude Code and Codex quota in the menu bar with burn-rate predictions, zero API calls
       - name: Package Managers
         repos:
           - url: https://github.com/milanvarady/Applite


### PR DESCRIPTION
Adds [usage](https://github.com/aqua5230/usage) — an open-source (AGPL-3.0) macOS menu bar app that pins Claude Code and Codex quota (5-hour / weekly) to the screen, with burn-rate predictions and offline HTML usage reports. It never calls the Anthropic/OpenAI API; all numbers come from local files, so monitoring adds zero token overhead. Installable via `brew install --cask aqua5230/usage/usage`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)