### PR TITLE
PinZheng(docs): add codex-profiles to developer utilities

### DIFF
--- a/repositories.yaml
+++ b/repositories.yaml
@@ -208,6 +208,8 @@ categories:
           - url: https://github.com/antonycourtney/tad
       - name: Developer Utilities
         repos:
+          - url: https://github.com/Ducksss/codex-profiles
+            description: Manage named Codex homes and separate ChatGPT windows
           - url: https://github.com/isaced/CubicBezier
           - url: https://github.com/hschmidt/EnvPane
           - url: https://github.com/onmyway133/FinderGo


### PR DESCRIPTION
## Summary

Adds [codex-profiles](https://github.com/Ducksss/codex-profiles) to **Developer Tools → Developer Utilities**. It is a dependency-free Bash utility for named Codex homes and, on macOS, separate ChatGPT Desktop windows with isolated local state.

## Fit

- Active project with its latest commit on July 14, 2026.
- MIT licensed with a public repository and documented installation paths.
- Provides a macOS workflow through its named ChatGPT Desktop launcher.

**Mark the following tasks as done:**

- [x] Checked `repositories.yaml` to ensure that the repository is not already listed.
- [x] Checked the pull requests to ensure that another person has not submitted it.
- [x] Read the contribution guidelines.
- [x] Modified only `repositories.yaml`.
- [x] Confirmed recent maintenance.
- [x] Confirmed the MIT open-source license.
