### PR TITLE
Add Pulse to System Tools > Menu Bar

### DIFF
--- a/repositories.yaml
+++ b/repositories.yaml
@@ -494,6 +494,8 @@ categories:
             description: All-in-one menu bar utility for Mac
           - url: https://github.com/Celve/Peninsula
             description: Dynamic Peninsula for window switching
+          - url: https://github.com/emgeorrk/pulse
+            description: Menu bar system monitor with live CPU, memory, temperature, fan, network, disk, power, and battery stats
           - url: https://github.com/DamascenoRafael/reminders-menubar
             description: View Apple Reminders in menu bar
           - url: https://github.com/FelixKratz/SketchyBar


### PR DESCRIPTION
**Mark the following tasks as done:**
- [x] Checked `repositories.yaml` to ensure that your repository is not already listed.
- [x] Checked the pull requests to ensure that another person hasn't already submitted the same repository.
- [x] Take note of the [contributing guidelines](https://github.com/abordage/awesome-mac/blob/main/.github/CONTRIBUTING.md).
- [x] Modified only the `repositories.yaml` file (README.md is automatically generated).
- [x] Repository being added is actively maintained (recent commits).
- [x] Repository being added has an open source license.

### Why it's worth adding

Adds **[Pulse](https://github.com/emgeorrk/pulse)** to *System Tools > Menu Bar*, alphabetically between *Peninsula* and *reminders-menubar* — next to *Hot*, the other menu bar hardware monitor in the subcategory.

- A feature-equivalent macOS counterpart of [Vitals](https://github.com/corecoding/Vitals), the popular GNOME Shell system-monitor extension that never existed on macOS — the same idea, rebuilt from scratch for the Mac.
- Free, open-source (MIT) menu bar system monitor with live CPU, memory, temperature, fan, network, disk, power, and battery stats.
- Reads everything from userspace — no sudo, no elevated privileges, no kernel extensions.
- Native app (Go + CGO over IOKit / SMC / HID / IOReport), tiny footprint, not Electron.
- Supports Apple Silicon and Intel; installable via a Homebrew tap or GitHub releases.

### Thanks for contributing!
