### PR TITLE
Add Hash Harbor

### DIFF
--- a/repositories.yaml
+++ b/repositories.yaml
@@ -293,6 +293,8 @@ categories:
       - name: Download Tools
         repos:
           - url: https://github.com/agalwood/Motrix
+          - url: https://github.com/apoorvdarshan/hash-harbor
+            description: Local torrent streamer and downloader with a native engine and browser interface
           - url: https://github.com/qbittorrent/qBittorrent
           - url: https://github.com/transmission/transmission
           - url: https://github.com/soimort/you-get


### PR DESCRIPTION
## What changed

Added Hash Harbor to **Networking → Download Tools**.

Hash Harbor is an MIT-licensed local torrent streamer and downloader with a native engine and browser interface. It supports macOS, Linux, and Windows.

## Validation

- Confirmed `repositories.yaml` parses successfully
- Ran `git diff --check`