### PR TITLE
Add Notate

### DIFF
--- a/repositories.yaml
+++ b/repositories.yaml
@@ -140,6 +140,8 @@ categories:
           - url: https://github.com/flameshot-org/flameshot
           - url: https://github.com/lihaoyun6/QuickRecorder
             description: Lightweight macOS screen recorder
+          - url: https://github.com/ahkohd/Notate.app
+            description: Annotate frozen screen states and animation frames
   - name: Developer Tools
     subcategories:
       - name: API Tools


### PR DESCRIPTION
## Summary

- Add `ahkohd/Notate.app` to **Design & Graphics > Screen Capture**.
- Include a concise, non-marketing description of its screen-state and animation-frame annotation workflow.

## Why

Notate is an active, open-source macOS app for annotating frozen screen states and individual animation frames.

## Checks

- Parsed `repositories.yaml` successfully.
- `git diff --check` passes.
