### PR TITLE
Add RelayBar to Remote Access

### DIFF
--- a/repositories.yaml
+++ b/repositories.yaml
@@ -322,6 +322,8 @@ categories:
           - url: https://github.com/LizardByte/Sunshine
           - url: https://github.com/electerm/electerm
             description: Terminal with SSH, SFTP, and RDP support
+          - url: https://github.com/lx2026/RelayBar
+            description: Native macOS menu bar app for SSH tunnels and remote file previews
   - name: Productivity
     subcategories:
       - name: Automation


### PR DESCRIPTION
Adds RelayBar to the Networking → Remote Access category. RelayBar is a native,
free, open-source macOS menu-bar app for managing SSH tunnels and previewing or
downloading exact remote paths.

Maintainer disclosure: I maintain RelayBar.

Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.

**Mark the following tasks as done:**
- [x] Checked `repositories.yaml` to ensure that the repository is not already listed.
- [x] Checked the pull requests to ensure that another person hasn't already submitted the same repository.
- [x] Took note of the [contributing guidelines](https://github.com/abordage/awesome-mac/blob/main/.github/CONTRIBUTING.md).
- [x] Modified only the `repositories.yaml` file (README.md is automatically generated).
- [x] Repository being added is actively maintained (recent commits).
- [x] Repository being added has an open source license.

### Thanks for contributing!
