### PR TITLE
Add AI Dictation

### DIFF
--- a/repositories.yaml
+++ b/repositories.yaml
@@ -47,6 +47,8 @@ categories:
             description: System-wide audio equalizer and mixer
           - url: https://github.com/chidiwilliams/buzz
             description: Offline audio transcription powered by Whisper
+          - url: https://github.com/writingmate/aidictation
+            description: "Native voice-to-text app for macOS with a configurable shortcut, offline recognition on supported Macs, and optional cloud transcription and cleanup."
           - url: https://github.com/AnaghSharma/Carol
           - url: https://github.com/sindresorhus/Gifski
           - url: https://github.com/lmms/lmms


### PR DESCRIPTION
## What changed

Added the AI Dictation repository to **Audio & Video → Utilities** with one factual macOS-specific description. Only `repositories.yaml` changed; the generated README remains untouched.

## Validation

- [x] Checked `repositories.yaml` to ensure that the repository is not already listed.
- [x] Checked open and closed pull requests and issues for another AI Dictation submission.
- [x] Read the contribution guidelines.
- [x] Modified only `repositories.yaml`.
- [x] Verified recent AI Dictation commits and releases.
- [x] Verified the public root MIT license.
- [x] Parsed the YAML, ran `git diff --check`, and checked the repository link.

## Disclosure

I am affiliated with AI Dictation and am submitting it openly rather than presenting this as an independent recommendation. This entry and pull-request text were prepared with AI assistance, then checked against the current project and this repository's contribution guide.
