### PR TITLE
Add MacBook 24x7 Agents

### DIFF
--- a/repositories.yaml
+++ b/repositories.yaml
@@ -546,6 +546,8 @@ categories:
           - url: https://github.com/Chris911/iStats
           - url: https://github.com/brianmichel/Juice
           - url: https://github.com/newmarcel/KeepingYouAwake
+          - url: https://github.com/apoorvdarshan/macbook-24x7-agents
+            description: Keep a MacBook running AI agents with the lid closed and display off.
           - url: https://github.com/BigBerny/magicquit
             description: Auto-quit unused apps for focus
           - url: https://github.com/alienator88/Pearcleaner


### PR DESCRIPTION
## What changed

Added `apoorvdarshan/macbook-24x7-agents` to **System Tools → System Utilities**.

The project provides reversible scripts for keeping a MacBook running background AI agents with the lid closed while turning displays off.

## Validation

- [x] Checked `repositories.yaml` to ensure that your repository is not already listed.
- [x] Checked the pull requests to ensure that another person hasn't already submitted the same repository.
- [x] Take note of the contributing guidelines.
- [x] Modified only the `repositories.yaml` file (README.md is automatically generated).
- [x] Repository being added is actively maintained (recent commits).
- [x] Repository being added has an open source license.
- [x] Parsed `repositories.yaml` successfully.
