### PR TITLE
Add Browser Cookie Bridge

### DIFF
--- a/repositories.yaml
+++ b/repositories.yaml
@@ -214,6 +214,8 @@ categories:
         repos:
           - url: https://github.com/Ducksss/codex-profiles
             description: Manage named Codex homes and separate ChatGPT windows
+          - url: https://github.com/apoorvdarshan/browser-cookie-bridge
+            description: Transfer signed-in sessions between local Chromium browsers and ChatGPT Codex on macOS.
           - url: https://github.com/isaced/CubicBezier
           - url: https://github.com/Avazbek22/DevProjex
             description: Cross-platform GUI and CLI for building structured project context with folder trees, file contents, token counting, Smart Ignore, preview, and multi-format export.


### PR DESCRIPTION
## Summary

Add Browser Cookie Bridge to **Developer Tools → Developer Utilities**. It is an open-source macOS utility for transferring signed-in sessions between local Chromium browsers and ChatGPT Codex.

**Mark the following tasks as done:**
- [x] Checked `repositories.yaml` to ensure that the repository is not already listed.
- [x] Checked open and closed pull requests to ensure that nobody has already submitted the repository.
- [x] Read the [contributing guidelines](https://github.com/abordage/awesome-mac/blob/main/.github/CONTRIBUTING.md).
- [x] Modified only `repositories.yaml`; `README.md` remains generated.
- [x] Confirmed that the repository is actively maintained with recent commits.
- [x] Confirmed that the repository is licensed under MIT.

## Validation

- parsed `repositories.yaml` successfully with Ruby YAML
- `git diff --check`
- verified the GitHub repository is public, active, and MIT-licensed
