### PR TITLE
Add FieldHop

### DIFF
--- a/repositories.yaml
+++ b/repositories.yaml
@@ -521,6 +521,8 @@ categories:
           - url: https://github.com/kmikiy/SpotMenu
           - url: https://github.com/aqua5230/usage
             description: Claude Code and Codex quota in the menu bar with burn-rate predictions, zero API calls
+          - url: https://github.com/18565882223-beep/fieldhop-macos
+            description: Local-first OTP relay from Messages or email to the correct field on macOS.
       - name: Package Managers
         repos:
           - url: https://github.com/milanvarady/Applite


### PR DESCRIPTION
Adds FieldHop, a local-first macOS menu bar utility that relays one-time codes from Messages or email to the correct input field.

- [x] Checked `repositories.yaml` to ensure that the repository is not already listed.
- [x] Checked open and closed pull requests for an existing FieldHop submission.
- [x] Read the contributing guidelines.
- [x] Modified only `repositories.yaml`.
- [x] Repository is actively maintained.
- [x] Repository has an MIT open-source license.