### PR TITLE
Add ItsPaint to Image Tools

### DIFF
--- a/repositories.yaml
+++ b/repositories.yaml
@@ -131,6 +131,8 @@ categories:
           - url: https://github.com/gee1k/uPic
           - url: https://github.com/upscayl/upscayl
             description: Free and Open Source AI Image Upscaler for Linux, MacOS and Windows
+          - url: https://github.com/joshlin2201/itspaint
+            description: MS Paint for the Mac with screenshot markup and pixel-art tools
       - name: Screen Capture
         repos:
           - url: https://github.com/wulkano/kap


### PR DESCRIPTION
Adding ItsPaint to **Design & Graphics → Image Tools** in `repositories.yaml`. I have not touched `README.md`, since it is generated.

[ItsPaint](https://github.com/joshlin2201/itspaint) is a native macOS paint and image editor: blank canvas at any size, crop, paste one image onto another, screenshot markup with numbered step badges and pixelate, and background removal with no model. MIT, Swift 6, no third-party dependencies, notarised, and free on the Mac App Store.

I put it under Image Tools rather than Screen Capture on purpose. Everything in Screen Capture is a recorder — kap, keycastr, licecap, obs-studio, QuickRecorder — and this marks up an image rather than capturing one.

Two-space indent, `url` and `description` only, matching the entries above it.
