### PR TITLE
docs(list): add Abendrot to desktop and system tools

### DIFF
--- a/repositories.yaml
+++ b/repositories.yaml
@@ -490,6 +490,8 @@ categories:
           - url: https://github.com/wflixu/RClick
           - url: https://github.com/sindresorhus/Actions
           - url: https://github.com/alin23/Lunar
+          - url: https://github.com/matthewrball/abendrot
+            description: Warms built-in and external Mac displays around local sunset.
           - url: https://github.com/thompsonate/Shifty
           - url: https://github.com/glinford/dns-easy-switcher
           - url: https://github.com/johnste/finicky


### PR DESCRIPTION
Adds Abendrot, which I maintain, to System Tools → Desktop & System beside other display-control utilities.

- [x] Checked `repositories.yaml` to ensure that the repository is not already listed.
- [x] Checked the pull requests to ensure that another person has not already submitted the same repository.
- [x] Took note of the [contributing guidelines](https://github.com/abordage/awesome-mac/blob/main/.github/CONTRIBUTING.md).
- [x] Modified only the `repositories.yaml` file (README.md is automatically generated).
- [x] Repository being added is actively maintained (recent commits).
- [x] Repository being added has an open source license.

### Thanks for contributing!