### PR TITLE
docs(list): add TetherShot to screen capture

### DIFF
--- a/repositories.yaml
+++ b/repositories.yaml
@@ -140,6 +140,8 @@ categories:
           - url: https://github.com/flameshot-org/flameshot
           - url: https://github.com/lihaoyun6/QuickRecorder
             description: Lightweight macOS screen recorder
+          - url: https://github.com/apoorvdarshan/TetherShot
+            description: Native macOS menu bar utility for capturing the actual iPhone display over USB or Wi-Fi and saving pixel-perfect PNGs locally.
   - name: Developer Tools
     subcategories:
       - name: API Tools


### PR DESCRIPTION
Adds TetherShot to Design & Graphics → Screen Capture.

- [x] Checked `repositories.yaml` for an existing TetherShot entry.
- [x] Checked pull requests for a duplicate submission.
- [x] Modified only `repositories.yaml`; `README.md` is generated.
- [x] TetherShot is an actively maintained open-source macOS app.
- [x] The entry uses the existing Screen Capture category.
