### PR TITLE
docs(list): add Tracexy to network analysis

### DIFF
--- a/repositories.yaml
+++ b/repositories.yaml
@@ -311,6 +311,8 @@ categories:
       - name: Network Analysis
         repos:
           - url: https://github.com/GyulyVGC/sniffnet
+          - url: https://github.com/RockxyApp/Tracexy
+            description: Native, local-first network intelligence for macOS
           - url: https://github.com/wireshark/wireshark
             description: Wireshark is a network traffic analyzer, or "sniffer"
       - name: Proxy & VPN


### PR DESCRIPTION
**Mark the following tasks as done:**
- [x] Checked `repositories.yaml` to ensure that your repository is not already listed.
- [x] Checked the pull requests to ensure that another person hasn’t already submitted the same repository.
- [x] Take note of the [contributing guidelines](https://github.com/abordage/awesome-mac/blob/main/.github/CONTRIBUTING.md).
- [x] Modified only the `repositories.yaml` file (README.md is automatically generated).
- [x] Repository being added is actively maintained (recent commits).
- [x] Repository being added has an open source license.

Adds [Tracexy](https://github.com/RockxyApp/Tracexy) to Networking → Network Analysis. Tracexy is a native, local-first network intelligence app for macOS and is licensed under AGPL-3.0.