### PR TITLE
docs(list): add Rockxy to API tools

### DIFF
--- a/repositories.yaml
+++ b/repositories.yaml
@@ -154,6 +154,8 @@ categories:
             description: Open source API development ecosystem
           - url: https://github.com/Kong/insomnia
             description: Cross-platform API client for REST, GraphQL, gRPC
+          - url: https://github.com/RockxyApp/Rockxy
+            description: Native macOS HTTP debugging proxy
           - url: https://github.com/mountain-loop/yaak
             description: Intuitive API client for REST and GraphQL
       - name: App Frameworks


### PR DESCRIPTION
**Mark the following tasks as done:**
- [x] Checked `repositories.yaml` to ensure that your repository is not already listed.
- [x] Checked the pull requests to ensure that another person hasn’t already submitted the same repository.
- [x] Take note of the [contributing guidelines](https://github.com/abordage/awesome-mac/blob/main/.github/CONTRIBUTING.md).
- [x] Modified only the `repositories.yaml` file (README.md is automatically generated).
- [x] Repository being added is actively maintained (recent commits).
- [x] Repository being added has an open source license.

Adds [Rockxy](https://github.com/RockxyApp/Rockxy) to Developer Tools → API Tools. Rockxy is a native macOS HTTP debugging proxy and is licensed under AGPL-3.0.