### PR TITLE
docs(list): add Shieldxy to system security

### DIFF
--- a/repositories.yaml
+++ b/repositories.yaml
@@ -459,6 +459,8 @@ categories:
           - url: https://github.com/objective-see/KnockKnock
           - url: https://github.com/halo/LinkLiar
           - url: https://github.com/objective-see/LuLu
+          - url: https://github.com/RockxyApp/Shieldxy
+            description: Auditable application firewall and connection monitor for macOS
           - url: https://github.com/objective-see/OverSight
             description: Monitor mic and webcam access on Mac
           - url: https://github.com/ParetoSecurity/pareto-mac


### PR DESCRIPTION
**Mark the following tasks as done:**
- [x] Checked `repositories.yaml` to ensure that your repository is not already listed.
- [x] Checked the pull requests to ensure that another person hasn’t already submitted the same repository.
- [x] Take note of the [contributing guidelines](https://github.com/abordage/awesome-mac/blob/main/.github/CONTRIBUTING.md).
- [x] Modified only the `repositories.yaml` file (README.md is automatically generated).
- [x] Repository being added is actively maintained (recent commits).
- [x] Repository being added has an open source license.

Adds [Shieldxy](https://github.com/RockxyApp/Shieldxy) to Security → System Security. Shieldxy is an auditable application firewall and connection monitor for macOS and is licensed under AGPL-3.0.